### PR TITLE
일부 컴포넌트 변경 및 모달 validation 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "emotion-normalize": "^11.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.53.0",
     "react-router-dom": "^6.26.2",
     "reset-css": "^5.0.2"
   },
@@ -29,6 +30,7 @@
     "@emotion/babel-plugin": "^11.12.0",
     "@eslint/js": "^9.9.0",
     "@feature-sliced/eslint-config": "^0.1.1",
+    "@hookform/error-message": "^2.0.1",
     "@storybook/addon-essentials": "8.3.4",
     "@storybook/addon-interactions": "8.3.4",
     "@storybook/addon-links": "8.3.4",

--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -10,12 +10,13 @@ interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement> {
   alt?: string;
   css?: CSSObject;
   size?: AvatarSize;
+  bordered?: boolean;
 }
 
 function Avatar({
-  src, alt, css, size, ...rest
+  src, alt, css, size, bordered = false, ...rest
 }: AvatarProps) {
-  const { avatarStyle } = useAvatarStyle({ size });
+  const { avatarStyle } = useAvatarStyle({ size, bordered });
   return (
     <img src={src || defaultAvatar} css={[avatarStyle, css]} alt={alt || 'avatar'} {...rest} />
   );

--- a/src/components/avatar/useAvatarStyle.ts
+++ b/src/components/avatar/useAvatarStyle.ts
@@ -3,15 +3,17 @@ import { type AvatarSize } from '@components/avatar/index';
 
 interface UseAvatarStyleProps {
   size?: AvatarSize;
+  bordered?: boolean;
 }
 
-function useAvatarStyle({ size }: UseAvatarStyleProps) {
+function useAvatarStyle({ size, bordered }: UseAvatarStyleProps) {
   const theme = useTheme();
 
   const avatarStyle = css`
     border-radius: ${theme.corners.round};
     width: ${getAvatarLength(size)};
     height: ${getAvatarLength(size)};
+    border: ${bordered ? `2px solid ${theme.colors.absolute.black};` : 'none'};
   `;
 
   return { avatarStyle };

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -9,7 +9,10 @@ const meta: Meta<typeof Button> = {
 
     variant: {
       control: 'radio',
-      options: ['default', 'dark', 'light-outlined'],
+      options: ['default', 'dark', 'primary'],
+    },
+    disabled: {
+      control: 'boolean',
     },
     children: {
       control: 'text',
@@ -43,11 +46,19 @@ export const CustomStyled: Story = {
     variant: 'default',
     children: 'Custom Styled Button',
     css: {
-      backgroundColor: 'lightblue',
-      padding: '10px 20px',
-      borderRadius: '5px',
-      border: 'none',
-      cursor: 'pointer',
+      "backgroundColor": "lightblue",
+      "padding": "10px 20px",
+      "borderRadius": "5px",
+      "cursor": "pointer"
     },
   },
+};
+
+export const Disabled: Story = {
+  args: {
+    variant: "primary",
+    children: "Dark Button",
+    icon: "/src/assets/icons/eye.svg",
+    disabled: true
+  }
 };

--- a/src/components/button/useButtonStyle.ts
+++ b/src/components/button/useButtonStyle.ts
@@ -8,6 +8,41 @@ interface UseButtonStyleProps {
 function useButtonStyle({ variant = 'default' }: UseButtonStyleProps) {
   const globalTheme = useTheme();
 
+  const variantStyles = {
+    default: {
+      backgroundColor: globalTheme.colors.background.main,
+      color: globalTheme.colors.text.prominent,
+      border: `1px solid ${globalTheme.colors.text.subtle}`,
+      hoverBackgroundColor: globalTheme.colors.background.darken,
+      hoverColor: globalTheme.colors.text.prominent,
+      hoverBorderColor: globalTheme.colors.border.prominent,
+      disabledBackgroundColor: globalTheme.colors.background.darken,
+      disabledColor: globalTheme.colors.text.subtle,
+    },
+    dark: {
+      backgroundColor: globalTheme.colors.text.prominent,
+      color: globalTheme.colors.primary.main,
+      border: '1px solid transparent',
+      hoverBackgroundColor: globalTheme.colors.primary.main,
+      hoverColor: globalTheme.colors.text.prominent,
+      hoverBorderColor: 'transparent',
+      disabledBackgroundColor: globalTheme.colors.border.subtle,
+      disabledColor: globalTheme.colors.text.subtle,
+    },
+    primary: {
+      backgroundColor: globalTheme.colors.primary.darken,
+      color: globalTheme.colors.absolute.white,
+      border: '1px solid transparent',
+      hoverBackgroundColor: globalTheme.colors.absolute.black,
+      hoverColor: globalTheme.colors.primary.main,
+      hoverBorderColor: 'transparent',
+      disabledBackgroundColor: globalTheme.colors.primary.passive,
+      disabledColor: globalTheme.colors.text.subtle,
+    },
+  };
+
+  const styles = variantStyles[variant];
+
   const buttonStyle = css`
     display: flex;
     align-items: center;
@@ -15,16 +50,23 @@ function useButtonStyle({ variant = 'default' }: UseButtonStyleProps) {
     outline: none;
     padding: 10px 18px;
     border-radius: 100px;
-    color: ${variant === 'dark' ? globalTheme.colors.primary.main : globalTheme.colors.text.prominent};
-    border: ${getBorderStyle()};
-    background-color: ${getBackgroundColor()};
+    color: ${styles.color};
+    border: ${styles.border};
+    background-color: ${styles.backgroundColor};
     transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
     cursor: pointer;
     gap: 5px;
+    
     &:hover {
-      background-color: ${getHoverBackgroundColor()};
-      color: ${getHoverColor()};
-      border-color: ${getHoverBorderColor()};
+      background-color: ${styles.hoverBackgroundColor};
+      color: ${styles.hoverColor};
+      border: 1px solid ${styles.hoverBorderColor};
+    }
+
+    &:disabled, &:disabled:hover {
+      background-color: ${styles.disabledBackgroundColor};
+      color: ${styles.disabledColor};
+      border: 1px solid transparent;
     }
   `;
 
@@ -32,56 +74,6 @@ function useButtonStyle({ variant = 'default' }: UseButtonStyleProps) {
     width: 16px;
     height: 16px;
   `;
-
-  function getBackgroundColor() {
-    if (variant === 'light-outlined') {
-      return 'transparent';
-    }
-
-    if (variant === 'dark') {
-      return globalTheme.colors.text.prominent;
-    }
-
-    return globalTheme.colors.background.main;
-  }
-
-  function getBorderStyle() {
-    if (variant === 'light-outlined') {
-      return `2px solid ${globalTheme.colors.absolute.black}`;
-    }
-
-    const baseStyle = '1px solid ';
-
-    return baseStyle + (variant === 'dark' ? 'transparent' : globalTheme.colors.text.subtle);
-  }
-
-  function getHoverBackgroundColor() {
-    if (variant === 'light-outlined') {
-      return globalTheme.colors.text.prominent;
-    }
-
-    if (variant === 'dark') {
-      return globalTheme.colors.primary.main;
-    }
-
-    return globalTheme.colors.background.darken;
-  }
-
-  function getHoverColor() {
-    if (variant === 'light-outlined') {
-      return globalTheme.colors.background.main;
-    }
-
-    return globalTheme.colors.text.prominent;
-  }
-
-  function getHoverBorderColor() {
-    if (variant === 'light-outlined') {
-      return globalTheme.colors.absolute.black;
-    }
-
-    return variant === 'dark' ? globalTheme.colors.primary.main : globalTheme.colors.border.prominent;
-  }
 
   return {
     buttonStyle,

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -75,6 +75,7 @@ const ModalContainer = styled.div<{ width?: string, height?: string }>`
   height: ${(props) => props.height || 'auto'};
   top: 50%;
   left: 50%;
+  padding: 0 20px;
   transform: translate(-50%, -50%);
   z-index: 1000;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -1,24 +1,44 @@
 import { ElementType, ReactNode } from 'react';
 import styled from '@emotion/styled';
+import { useTheme } from '@emotion/react';
 
 export type FontWeight = 'regular' | 'medium' | 'bold' | 'lighter' | 'bolder';
 
 interface TextProps {
   children: ReactNode;
+  // eslint-disable-next-line react/no-unused-prop-types
   weight?: FontWeight;
   // eslint-disable-next-line react/no-unused-prop-types
   as?: ElementType;
   // eslint-disable-next-line react/no-unused-prop-types
   fontSize?: string;
+  // eslint-disable-next-line react/no-unused-prop-types
+  color?: string;
 }
 
 const Text = styled.p<TextProps>`
     font-weight: ${({ weight }) => weight || 'regular'};
     margin: 0;
-    ${({ fontSize }) => fontSize && `font-size: ${fontSize};`}
+    ${({ fontSize }) => fontSize && `font-size: ${fontSize};`};
+    ${({ color }) => color && `color: ${color};`};
 `;
 
 export default Text;
+
+export const ErrorText = {
+  Large: ({ children }: TextProps) => {
+    const theme = useTheme();
+    return <Text as="p" fontSize="16px" color={theme.colors.other.error}>{children}</Text>;
+  },
+  Medium: ({ children }: TextProps) => {
+    const theme = useTheme();
+    return <Text as="p" fontSize="14px" color={theme.colors.other.error}>{children}</Text>;
+  },
+  Small: ({ children }: TextProps) => {
+    const theme = useTheme();
+    return <Text as="p" fontSize="12px" color={theme.colors.other.error}>{children}</Text>;
+  },
+};
 
 export const Paragraph = {
   Large: ({ children, weight }: TextProps) => (

--- a/src/components/text/variants/index.tsx
+++ b/src/components/text/variants/index.tsx
@@ -1,7 +1,7 @@
-import Spacing from '@components/spacing';
 import { ErrorText } from '@components/text';
 import { ErrorMessage } from '@hookform/error-message';
 import { FieldErrors } from 'react-hook-form';
+import { css } from '@emotion/react';
 
 interface FormErrorMessageProps {
   errors: FieldErrors;
@@ -11,13 +11,18 @@ interface FormErrorMessageProps {
 // eslint-disable-next-line
 export function FormErrorMessage({ errors, name }: FormErrorMessageProps) {
   return (
-    <>
-      <Spacing height={2} />
-      <ErrorMessage
-        name={name}
-        errors={errors}
-        render={({ message }) => <ErrorText.Small>{message}</ErrorText.Small>}
-      />
-    </>
+    <ErrorMessage
+      name={name}
+      errors={errors}
+      render={({ message }) => (
+        <div css={messageContainerStyle}>
+          <ErrorText.Small>{message}</ErrorText.Small>
+        </div>
+      )}
+    />
   );
 }
+
+const messageContainerStyle = css`
+  padding-top: 3px;
+`;

--- a/src/components/text/variants/index.tsx
+++ b/src/components/text/variants/index.tsx
@@ -1,0 +1,23 @@
+import Spacing from '@components/spacing';
+import { ErrorText } from '@components/text';
+import { ErrorMessage } from '@hookform/error-message';
+import { FieldErrors } from 'react-hook-form';
+
+interface FormErrorMessageProps {
+  errors: FieldErrors;
+  name: string;
+}
+
+// eslint-disable-next-line
+export function FormErrorMessage({ errors, name }: FormErrorMessageProps) {
+  return (
+    <>
+      <Spacing height={2} />
+      <ErrorMessage
+        name={name}
+        errors={errors}
+        render={({ message }) => <ErrorText.Small>{message}</ErrorText.Small>}
+      />
+    </>
+  );
+}

--- a/src/components/textarea/index.tsx
+++ b/src/components/textarea/index.tsx
@@ -41,6 +41,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextareaProps>(({
         cols={cols}
         maxLength={maxLength}
         ref={ref}
+        onChange={onChange}
         {...rest}
       />
     </>

--- a/src/features/modal/login/LoginModal.tsx
+++ b/src/features/modal/login/LoginModal.tsx
@@ -10,7 +10,6 @@ import GithubIcon from '@/assets/github.svg';
 import InstagramIcon from '@/assets/instagram.svg';
 import BlogIcon from '@/assets/blog.svg';
 import Spacing from '@/components/spacing';
-import { DefaultPaddedContainer } from '@/components/container/variants';
 
 interface LoginModalProps {
   open: boolean;
@@ -20,31 +19,28 @@ interface LoginModalProps {
 function LoginModal({ open, onClose }: LoginModalProps) {
   const { kakaoLoginButtonStyle, iconButtonBaseStyle } = useLoginModalStyles();
   return (
-    <DefaultPaddedContainer>
-      <Modal open={open} onClose={onClose} width="387px" height="478px">
+    <Modal open={open} onClose={onClose} width="387px" height="478px">
+      <Container padding="82px 30px" direction="column">
+        <img src={Logo} alt="Logo" />
+        <Spacing height={12} />
+        <Paragraph.Medium>함께하면 더 강해진다!</Paragraph.Medium>
+        <Paragraph.Medium>Ditto와 함께 시작하세요.</Paragraph.Medium>
+      </Container>
 
-        <Container padding="82px 30px" direction="column">
-          <img src={Logo} alt="Logo" />
-          <Spacing height={12} />
-          <Paragraph.Medium>함께하면 더 강해진다!</Paragraph.Medium>
-          <Paragraph.Medium>Ditto와 함께 시작하세요.</Paragraph.Medium>
-        </Container>
+      <Container padding="16px 30px" direction="column">
+        <Paragraph.Small weight="lighter">sns로 5초만에 시작하기</Paragraph.Small>
+        <Spacing height={12} />
+        <Button icon={BubbleIcon} css={kakaoLoginButtonStyle}>카카오 계정으로 로그인</Button>
+      </Container>
 
-        <Container padding="16px 30px" direction="column">
-          <Paragraph.Small weight="lighter">sns로 5초만에 시작하기</Paragraph.Small>
-          <Spacing height={12} />
-          <Button icon={BubbleIcon} css={kakaoLoginButtonStyle}>카카오 계정으로 로그인</Button>
-        </Container>
-
-        <Container padding="0 80px" direction="column">
-          <Grid columns={3} gap={24} style={{ placeItems: 'center' }}>
-            <Button css={iconButtonBaseStyle} style={{ backgroundImage: `url(${GithubIcon})` }} />
-            <Button css={iconButtonBaseStyle} style={{ backgroundImage: `url(${InstagramIcon})` }} />
-            <Button css={iconButtonBaseStyle} style={{ backgroundImage: `url(${BlogIcon})` }} />
-          </Grid>
-        </Container>
-      </Modal>
-    </DefaultPaddedContainer>
+      <Container padding="0 80px" direction="column">
+        <Grid columns={3} gap={24} style={{ placeItems: 'center' }}>
+          <Button css={iconButtonBaseStyle} style={{ backgroundImage: `url(${GithubIcon})` }} />
+          <Button css={iconButtonBaseStyle} style={{ backgroundImage: `url(${InstagramIcon})` }} />
+          <Button css={iconButtonBaseStyle} style={{ backgroundImage: `url(${BlogIcon})` }} />
+        </Grid>
+      </Container>
+    </Modal>
   );
 }
 

--- a/src/features/modal/login/PersonalInfoModal.styles.ts
+++ b/src/features/modal/login/PersonalInfoModal.styles.ts
@@ -3,10 +3,6 @@ import colorTheme from '@/styles/colors';
 import corners from '@/styles/corners';
 
 export default function usePersonInfoModaStyles() {
-  const avatarStyle = css`
-    border: 2px solid ${colorTheme.absolute.black};
-  `;
-
   const selectPhotoButtonStyle = css`
     border: none;
     color: ${colorTheme.primary.main};
@@ -41,6 +37,6 @@ export default function usePersonInfoModaStyles() {
   `;
 
   return {
-    avatarStyle, selectPhotoButtonStyle, linkTextStyle, textStyle, signUpButtonStyle,
+    selectPhotoButtonStyle, linkTextStyle, textStyle, signUpButtonStyle,
   };
 }

--- a/src/features/modal/login/PersonalInfoModal.styles.ts
+++ b/src/features/modal/login/PersonalInfoModal.styles.ts
@@ -24,19 +24,7 @@ export default function usePersonInfoModaStyles() {
     color: ${colorTheme.text.subtle};
   `;
 
-  const signUpButtonStyle = css`
-    width: 100%;
-    background-color: ${colorTheme.primary.darken};
-    color: ${colorTheme.absolute.white};
-    border: none;
-    border-radius: ${corners.medium};
-    &:hover {
-      background-color: ${colorTheme.absolute.black};
-      color: ${colorTheme.primary.main};
-    }
-  `;
-
   return {
-    selectPhotoButtonStyle, linkTextStyle, textStyle, signUpButtonStyle,
+    selectPhotoButtonStyle, linkTextStyle, textStyle,
   };
 }

--- a/src/features/modal/login/PersonalInfoModal.styles.ts
+++ b/src/features/modal/login/PersonalInfoModal.styles.ts
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import colorTheme from '@/styles/colors';
-import corners from '@/styles/corners';
 
 export default function usePersonInfoModaStyles() {
   const selectPhotoButtonStyle = css`

--- a/src/features/modal/login/PersonalInfoModal.tsx
+++ b/src/features/modal/login/PersonalInfoModal.tsx
@@ -2,7 +2,6 @@ import Avatar from '@/components/avatar';
 import Button from '@/components/button';
 import Checkbox from '@/components/checkbox';
 import Container from '@/components/container';
-import { DefaultPaddedContainer } from '@/components/container/variants';
 import Grid from '@/components/grid';
 import Input from '@/components/input';
 import Modal from '@/components/modal';
@@ -18,53 +17,50 @@ interface PersonalInfoModalProps {
 
 export default function PersonalInfoModal({ open, onClose }: PersonalInfoModalProps) {
   const {
-    avatarStyle, selectPhotoButtonStyle, linkTextStyle, textStyle, signUpButtonStyle,
+    selectPhotoButtonStyle, linkTextStyle, textStyle, signUpButtonStyle,
   } = usePersonInfoModaStyles();
   return (
-    <DefaultPaddedContainer>
-      <Modal open={open} onClose={onClose} width="447px">
-        <Container padding="30px" direction="column" align="flex-start">
-          <Heading.H3 weight="bold">개인 정보를 입력해주세요.</Heading.H3>
-        </Container>
+    <Modal open={open} onClose={onClose} width="447px">
+      <Container padding="30px" direction="column" align="flex-start">
+        <Heading.H3 weight="bold">개인 정보를 입력해주세요.</Heading.H3>
+      </Container>
 
-        <Container direction="column" gap="6px">
-          <Avatar size="large" css={avatarStyle} />
-          <Button css={selectPhotoButtonStyle}>프로필 사진 등록</Button>
-        </Container>
+      <Container direction="column" gap="6px">
+        <Avatar size="large" bordered />
+        <Button css={selectPhotoButtonStyle}>프로필 사진 등록</Button>
+      </Container>
 
-        <Container padding="12px 30px">
-          <Grid columns={1}>
-            <Input label="닉네임" placeholder="디토에서 사용할 닉네임이에요." type="text" />
-            <Spacing height={10} />
-            <Input label="이메일" placeholder="이메일 주소를 입력해주세요." type="email" />
-            <Spacing height={10} />
-            <Input label="연락처" placeholder="연락 가능한 번호를 입력해주세요." type="tel" />
-            <Spacing height={10} />
-            <TextArea rows={1} label="자기소개" resize="vertical" />
-          </Grid>
-        </Container>
+      <Container padding="12px 30px">
+        <Grid columns={1}>
+          <Input label="닉네임" placeholder="디토에서 사용할 닉네임이에요." type="text" />
+          <Spacing height={10} />
+          <Input label="이메일" placeholder="이메일 주소를 입력해주세요." type="email" />
+          <Spacing height={10} />
+          <Input label="연락처" placeholder="연락 가능한 번호를 입력해주세요." type="tel" />
+          <Spacing height={10} />
+          <TextArea rows={1} label="자기소개" resize="vertical" />
+        </Grid>
+      </Container>
 
-        <Container gap="5px">
-          <Checkbox />
-          <div css={textStyle}>
-            <Paragraph.Small>
-              <a href="https://github.com/kakao-tech-campus-2nd-step3/Team12_FE" css={linkTextStyle}>개인정보 처리방침</a>
-              {' '}
-              및
-              {' '}
-              <a href="https://github.com/kakao-tech-campus-2nd-step3/Team12_FE" css={linkTextStyle}>이용약관</a>
-              에 동의해요.
-            </Paragraph.Small>
-          </div>
-        </Container>
+      <Container gap="5px">
+        <Checkbox />
+        <div css={textStyle}>
+          <Paragraph.Small>
+            <a href="https://github.com/kakao-tech-campus-2nd-step3/Team12_FE" css={linkTextStyle}>개인정보 처리방침</a>
+            {' '}
+            및
+            {' '}
+            <a href="https://github.com/kakao-tech-campus-2nd-step3/Team12_FE" css={linkTextStyle}>이용약관</a>
+            에 동의해요.
+          </Paragraph.Small>
+        </div>
+      </Container>
 
-        <Container padding="12px 30px">
-          <Button css={signUpButtonStyle}>가입하기</Button>
-        </Container>
+      <Container padding="12px 30px">
+        <Button css={signUpButtonStyle}>가입하기</Button>
+      </Container>
 
-        <Spacing height={20} />
-
-      </Modal>
-    </DefaultPaddedContainer>
+      <Spacing height={20} />
+    </Modal>
   );
 }

--- a/src/features/modal/login/PersonalInfoModal.tsx
+++ b/src/features/modal/login/PersonalInfoModal.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '@emotion/react';
 import Avatar from '@/components/avatar';
 import Button from '@/components/button';
 import Checkbox from '@/components/checkbox';
@@ -17,8 +18,9 @@ interface PersonalInfoModalProps {
 
 export default function PersonalInfoModal({ open, onClose }: PersonalInfoModalProps) {
   const {
-    selectPhotoButtonStyle, linkTextStyle, textStyle, signUpButtonStyle,
+    selectPhotoButtonStyle, linkTextStyle, textStyle,
   } = usePersonInfoModaStyles();
+  const theme = useTheme();
   return (
     <Modal open={open} onClose={onClose} width="447px">
       <Container padding="30px" direction="column" align="flex-start">
@@ -57,7 +59,7 @@ export default function PersonalInfoModal({ open, onClose }: PersonalInfoModalPr
       </Container>
 
       <Container padding="12px 30px">
-        <Button css={signUpButtonStyle}>가입하기</Button>
+        <Button variant="primary" css={{ borderRadius: theme.corners.small, width: '100%' }}>가입하기</Button>
       </Container>
 
       <Spacing height={20} />

--- a/src/features/modal/studyCreation/InviteToStudyModal.tsx
+++ b/src/features/modal/studyCreation/InviteToStudyModal.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, useTheme } from '@emotion/react';
 import Avatar from '@/components/avatar';
 import Button from '@/components/button';
 import Container from '@/components/container';
@@ -16,7 +16,8 @@ interface StudyCreationProps {
 }
 
 export default function InviteToStudyModal({ open, onClose }: StudyCreationProps) {
-  const { selectPhotoButtonStyle, creationButtonStyle } = useStudyCreationStyle();
+  const { selectPhotoButtonStyle } = useStudyCreationStyle();
+  const theme = useTheme();
   return (
     <Modal open={open} onClose={onClose} width="447px">
       <Container padding="30px" direction="column" align="flex-start">
@@ -38,8 +39,16 @@ export default function InviteToStudyModal({ open, onClose }: StudyCreationProps
             readOnly
             label="초대 링크"
           />
-          <Spacing height={20} />
-          <Button css={creationButtonStyle}>링크 공유하기</Button>
+          <Spacing height={18} />
+          <Button
+            variant="primary"
+            css={{
+              width: '100%',
+              borderRadius: theme.corners.medium,
+            }}
+          >
+            링크 공유하기
+          </Button>
         </Grid>
       </Container>
     </Modal>

--- a/src/features/modal/studyCreation/InviteToStudyModal.tsx
+++ b/src/features/modal/studyCreation/InviteToStudyModal.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import Avatar from '@/components/avatar';
 import Button from '@/components/button';
 import Container from '@/components/container';
-import { DefaultPaddedContainer } from '@/components/container/variants';
 import Modal from '@/components/modal';
 import { Heading, Paragraph } from '@/components/text';
 import useStudyCreationStyle from './StudyCreation.styles';
@@ -17,34 +16,32 @@ interface StudyCreationProps {
 }
 
 export default function InviteToStudyModal({ open, onClose }: StudyCreationProps) {
-  const { avatarStyle, selectPhotoButtonStyle, creationButtonStyle } = useStudyCreationStyle();
+  const { selectPhotoButtonStyle, creationButtonStyle } = useStudyCreationStyle();
   return (
-    <DefaultPaddedContainer>
-      <Modal open={open} onClose={onClose} width="447px">
-        <Container padding="30px" direction="column" align="flex-start">
-          <Heading.H3 weight="bold">다른 사람을 스터디에 초대해보세요.</Heading.H3>
+    <Modal open={open} onClose={onClose} width="447px">
+      <Container padding="30px" direction="column" align="flex-start">
+        <Heading.H3 weight="bold">다른 사람을 스터디에 초대해보세요.</Heading.H3>
 
-          <Container direction="column" gap="6px" cssOverride={css`font-weight: bold`} padding="30px">
-            <Avatar size="large" css={avatarStyle} />
-            <Button css={selectPhotoButtonStyle}>Ditto Study</Button>
-            <Container direction="column" cssOverride={css`color: ${colorTheme.text.moderate}`}>
-              <Paragraph.Small>OOO님이 Ditto Study에 초대했어요!</Paragraph.Small>
-              <Paragraph.Small>아래 링크를 통해 가입해주세요.</Paragraph.Small>
-            </Container>
+        <Container direction="column" gap="6px" cssOverride={css`font-weight: bold`} padding="30px">
+          <Avatar size="large" bordered />
+          <Button css={selectPhotoButtonStyle}>Ditto Study</Button>
+          <Container direction="column" cssOverride={css`color: ${colorTheme.text.moderate}`}>
+            <Paragraph.Small>OOO님이 Ditto Study에 초대했어요!</Paragraph.Small>
+            <Paragraph.Small>아래 링크를 통해 가입해주세요.</Paragraph.Small>
           </Container>
-
-          <Grid columns={1}>
-            <Input
-              type="text"
-              value="https://discord.gg/RHphspSM"
-              readOnly
-              label="초대 링크"
-            />
-            <Spacing height={20} />
-            <Button css={creationButtonStyle}>링크 공유하기</Button>
-          </Grid>
         </Container>
-      </Modal>
-    </DefaultPaddedContainer>
+
+        <Grid columns={1}>
+          <Input
+            type="text"
+            value="https://discord.gg/RHphspSM"
+            readOnly
+            label="초대 링크"
+          />
+          <Spacing height={20} />
+          <Button css={creationButtonStyle}>링크 공유하기</Button>
+        </Grid>
+      </Container>
+    </Modal>
   );
 }

--- a/src/features/modal/studyCreation/LeftSection.tsx
+++ b/src/features/modal/studyCreation/LeftSection.tsx
@@ -8,7 +8,7 @@ import Spacing from '@/components/spacing';
 import Grid from '@/components/grid';
 
 export default function LeftSection() {
-  const { avatarStyle, selectPhotoButtonStyle, textStyle } = useStudyCreationStyle();
+  const { selectPhotoButtonStyle, textStyle } = useStudyCreationStyle();
   return (
     <Container direction="column" gap="30px">
       <Container direction="column" align="flex-start">
@@ -16,7 +16,7 @@ export default function LeftSection() {
       </Container>
 
       <Container direction="column" gap="6px">
-        <Avatar size="large" css={avatarStyle} />
+        <Avatar size="large" bordered />
         <Button css={selectPhotoButtonStyle}>스터디 사진 등록</Button>
       </Container>
 

--- a/src/features/modal/studyCreation/LeftSection.tsx
+++ b/src/features/modal/studyCreation/LeftSection.tsx
@@ -1,3 +1,7 @@
+import {
+  type StudyCreationSectionProps,
+} from '@features/modal/studyCreation/StudyCreationModal';
+import { FormErrorMessage } from '@components/text/variants';
 import Avatar from '@/components/avatar';
 import Button from '@/components/button';
 import Container from '@/components/container';
@@ -7,7 +11,10 @@ import useStudyCreationStyle from './StudyCreation.styles';
 import Spacing from '@/components/spacing';
 import Grid from '@/components/grid';
 
-export default function LeftSection() {
+export default function LeftSection({
+  register,
+  formState: { errors },
+}: StudyCreationSectionProps) {
   const { selectPhotoButtonStyle, textStyle } = useStudyCreationStyle();
   return (
     <Container direction="column" gap="30px">
@@ -22,9 +29,23 @@ export default function LeftSection() {
 
       <Container direction="column" align="flex-start">
         <Grid columns={1}>
-          <Input label="스터디명" placeholder="최대 15자까지 입력 가능해요." type="text" />
+          <Input
+            label="스터디명"
+            placeholder="최대 15자까지 입력 가능해요."
+            type="text"
+            maxLength={15}
+            {...register('name', { ...validations.name })}
+          />
+          <FormErrorMessage errors={errors} name="name" />
           <Spacing height={10} />
-          <Input label="스터디 주제" placeholder="ex)코딩 스터디" type="text" />
+          <Input
+            label="스터디 주제"
+            placeholder="ex)코딩 스터디"
+            type="text"
+            {...register('topic', { ...validations.topic })}
+          />
+          <Spacing height={2} />
+          <FormErrorMessage errors={errors} name="topic" />
           <Spacing height={10} />
           <div css={textStyle}>
             <Paragraph.Small>부적절한 내용의 스터디 생성 시 이용이 제한될 수 있어요.</Paragraph.Small>
@@ -35,3 +56,8 @@ export default function LeftSection() {
     </Container>
   );
 }
+
+const validations = {
+  name: { required: { value: true, message: '스터디 이름을 입력하세요.' } },
+  topic: { required: { value: true, message: '스터디 주제를 입력하세요.' } },
+};

--- a/src/features/modal/studyCreation/RightSection.tsx
+++ b/src/features/modal/studyCreation/RightSection.tsx
@@ -1,4 +1,8 @@
 import { css } from '@emotion/react';
+import {
+  type StudyCreationSectionProps,
+} from '@features/modal/studyCreation/StudyCreationModal';
+import { FormErrorMessage } from '@components/text/variants';
 import Button from '@/components/button';
 import Container from '@/components/container';
 import Switch from '@/components/switch';
@@ -7,17 +11,30 @@ import Textarea from '@/components/textarea';
 import colorTheme from '@/styles/colors';
 import useStudyCreationStyle from './StudyCreation.styles';
 
-export default function RightSection() {
+export default function RightSection({
+  register,
+  formState: { errors, isValid },
+}: StudyCreationSectionProps) {
   const { creationButtonStyle } = useStudyCreationStyle();
   return (
-    <Container direction="column" gap="10px" align="flex-start">
-      <Textarea label="스터디 설명" rows={14} resize="none" />
+    <Container direction="column" align="flex-start">
+      <Textarea
+        label="스터디 설명"
+        rows={14}
+        resize="none"
+        {...register('description', { ...validations.description })}
+      />
+      <FormErrorMessage errors={errors} name="description" />
       <Container cssOverride={css`color: ${colorTheme.text.subtle}`} gap="5px" justify="flex-start" padding="10px">
         <Paragraph.Small>비공개</Paragraph.Small>
-        <Switch type="checkbox" defaultChecked />
+        <Switch type="checkbox" {...register('isOpen')} defaultChecked />
         <Paragraph.Small>공개</Paragraph.Small>
       </Container>
-      <Button css={creationButtonStyle}>스터디 생성하기</Button>
+      <Button css={creationButtonStyle} type="submit" disabled={!isValid}>스터디 생성하기</Button>
     </Container>
   );
 }
+
+const validations = {
+  description: { required: { value: true, message: '스터디 설명을 입력하세요.' } },
+};

--- a/src/features/modal/studyCreation/RightSection.tsx
+++ b/src/features/modal/studyCreation/RightSection.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, useTheme } from '@emotion/react';
 import {
   type StudyCreationSectionProps,
 } from '@features/modal/studyCreation/StudyCreationModal';
@@ -9,13 +9,12 @@ import Switch from '@/components/switch';
 import { Paragraph } from '@/components/text';
 import Textarea from '@/components/textarea';
 import colorTheme from '@/styles/colors';
-import useStudyCreationStyle from './StudyCreation.styles';
 
 export default function RightSection({
   register,
   formState: { errors, isValid },
 }: StudyCreationSectionProps) {
-  const { creationButtonStyle } = useStudyCreationStyle();
+  const theme = useTheme();
   return (
     <Container direction="column" align="flex-start">
       <Textarea
@@ -30,7 +29,17 @@ export default function RightSection({
         <Switch type="checkbox" {...register('isOpen')} defaultChecked />
         <Paragraph.Small>공개</Paragraph.Small>
       </Container>
-      <Button css={creationButtonStyle} type="submit" disabled={!isValid}>스터디 생성하기</Button>
+      <Button
+        variant="primary"
+        type="submit"
+        disabled={!isValid}
+        css={{
+          width: '100%',
+          borderRadius: theme.corners.medium,
+        }}
+      >
+        스터디 생성하기
+      </Button>
     </Container>
   );
 }

--- a/src/features/modal/studyCreation/StudyCreation.styles.ts
+++ b/src/features/modal/studyCreation/StudyCreation.styles.ts
@@ -3,10 +3,6 @@ import colorTheme from '@/styles/colors';
 import corners from '@/styles/corners';
 
 export default function useStudyCreationStyle() {
-  const avatarStyle = css`
-    border: 2px solid ${colorTheme.absolute.black};
-  `;
-
   const selectPhotoButtonStyle = css`
     border: none;
     color: ${colorTheme.primary.main};
@@ -31,6 +27,6 @@ export default function useStudyCreationStyle() {
   color: ${colorTheme.text.subtle};
   `;
   return {
-    avatarStyle, selectPhotoButtonStyle, creationButtonStyle, textStyle,
+    selectPhotoButtonStyle, creationButtonStyle, textStyle,
   };
 }

--- a/src/features/modal/studyCreation/StudyCreation.styles.ts
+++ b/src/features/modal/studyCreation/StudyCreation.styles.ts
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import colorTheme from '@/styles/colors';
-import corners from '@/styles/corners';
 
 export default function useStudyCreationStyle() {
   const selectPhotoButtonStyle = css`
@@ -11,22 +10,11 @@ export default function useStudyCreationStyle() {
       background-color: transparent;
     }
   `;
-  const creationButtonStyle = css`
-  width: 100%;
-  background-color: ${colorTheme.primary.darken};
-  color: ${colorTheme.absolute.white};
-  border: none;
-  border-radius: ${corners.medium};
-  &:hover {
-    background-color: ${colorTheme.absolute.black};
-    color: ${colorTheme.primary.main};
-  }
-`;
 
   const textStyle = css`
-  color: ${colorTheme.text.subtle};
+    color: ${colorTheme.text.subtle};
   `;
   return {
-    selectPhotoButtonStyle, creationButtonStyle, textStyle,
+    selectPhotoButtonStyle, textStyle,
   };
 }

--- a/src/features/modal/studyCreation/StudyCreationModal.tsx
+++ b/src/features/modal/studyCreation/StudyCreationModal.tsx
@@ -1,5 +1,4 @@
 import Container from '@/components/container';
-import { DefaultPaddedContainer } from '@/components/container/variants';
 import Modal from '@/components/modal';
 import LeftSection from '@/features/modal/studyCreation/LeftSection';
 import RightSection from '@/features/modal/studyCreation/RightSection';
@@ -11,13 +10,11 @@ interface StudyCreationProps {
 
 export default function StudyCreationModal({ open, onClose }: StudyCreationProps) {
   return (
-    <DefaultPaddedContainer>
-      <Modal open={open} onClose={onClose} width="850px" height="450px">
-        <Container padding="30px" gap="30px" align="flex-start">
-          <LeftSection />
-          <RightSection />
-        </Container>
-      </Modal>
-    </DefaultPaddedContainer>
+    <Modal open={open} onClose={onClose} width="850px" height="450px">
+      <Container padding="30px" gap="30px" align="flex-start">
+        <LeftSection />
+        <RightSection />
+      </Container>
+    </Modal>
   );
 }

--- a/src/features/modal/studyCreation/StudyCreationModal.tsx
+++ b/src/features/modal/studyCreation/StudyCreationModal.tsx
@@ -1,7 +1,9 @@
-import Container from '@/components/container';
+import { css } from '@emotion/react';
+import { FormState, useForm, UseFormRegister } from 'react-hook-form';
 import Modal from '@/components/modal';
 import LeftSection from '@/features/modal/studyCreation/LeftSection';
 import RightSection from '@/features/modal/studyCreation/RightSection';
+import { type StudyCreationInputs } from '@/types/study';
 
 interface StudyCreationProps {
   open: boolean;
@@ -9,12 +11,40 @@ interface StudyCreationProps {
 }
 
 export default function StudyCreationModal({ open, onClose }: StudyCreationProps) {
+  const {
+    register,
+    handleSubmit,
+    formState,
+  } = useForm<StudyCreationInputs>({
+    defaultValues: {
+      isOpen: true,
+      name: '',
+      topic: '',
+      description: '',
+    },
+    mode: 'onChange',
+  });
+
+  // TODO: 실제 request 로직으로 변경 및 UI 로직과 분리
+  const onSubmit = (data: StudyCreationInputs) => console.log(data);
+
   return (
-    <Modal open={open} onClose={onClose} width="850px" height="450px">
-      <Container padding="30px" gap="30px" align="flex-start">
-        <LeftSection />
-        <RightSection />
-      </Container>
+    <Modal open={open} onClose={onClose} width="850px">
+      <form css={formStyle} onSubmit={handleSubmit(onSubmit)}>
+        <LeftSection formState={formState} register={register} />
+        <RightSection formState={formState} register={register} />
+      </form>
     </Modal>
   );
+}
+
+const formStyle = css`
+  display: flex;
+  gap: 30px;
+  padding: 30px;
+`;
+
+export interface StudyCreationSectionProps {
+  register: UseFormRegister<StudyCreationInputs>;
+  formState: FormState<StudyCreationInputs>;
 }

--- a/src/styles/index.d.ts
+++ b/src/styles/index.d.ts
@@ -1,6 +1,6 @@
 import '@emotion/react';
 
-export type ButtonVariants = 'default' | 'dark' | 'light-outlined';
+export type ButtonVariants = 'default' | 'dark' | 'primary';
 
 export type TagVariants = 'default' | 'primary';
 

--- a/src/types/study/index.d.ts
+++ b/src/types/study/index.d.ts
@@ -5,5 +5,11 @@ export interface Study {
   createdAt: Date;
   isOpen: boolean;
   topic: string;
-  profileImage?: string;
+  // profileImage?: string;
 }
+
+// TODO: 추후에 profileImage input 구현 후 타입 변경
+// export type StudyCreationRequestBody =
+//  Pick<Study, 'name' | 'description' | 'isOpen' | 'topic' | 'profileImage'>;
+export type StudyCreationRequestBody = Pick<Study, 'name' | 'description' | 'isOpen' | 'topic'>;
+export type StudyCreationInputs = StudyCreationRequestBody;

--- a/yarn.lock
+++ b/yarn.lock
@@ -890,6 +890,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hookform/error-message@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@hookform/error-message@npm:2.0.1"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+    react-hook-form: ^7.0.0
+  checksum: 10c0/6b608bcdbd797ddb7c6cfc8c42b6bbac40066181a0c582b1f1a342bfa65fa7e8329cdb8e869a76e33988cd46fe8623d521ea597231b9d33e1f0ba3288e36c58e
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.14":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14"
@@ -3658,6 +3669,7 @@ __metadata:
     "@emotion/styled": "npm:^11.13.0"
     "@eslint/js": "npm:^9.9.0"
     "@feature-sliced/eslint-config": "npm:^0.1.1"
+    "@hookform/error-message": "npm:^2.0.1"
     "@storybook/addon-essentials": "npm:8.3.4"
     "@storybook/addon-interactions": "npm:8.3.4"
     "@storybook/addon-links": "npm:8.3.4"
@@ -3688,6 +3700,7 @@ __metadata:
     globals: "npm:^15.9.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
+    react-hook-form: "npm:^7.53.0"
     react-router-dom: "npm:^6.26.2"
     reset-css: "npm:^5.0.2"
     storybook: "npm:8.3.4"
@@ -6823,6 +6836,15 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
   checksum: 10c0/0d60a0ea758529c32a706d0c69d70b69fb94de3c46442fffdee34f08f51ffceddbb5395b41dfd1565895653e9f60f98ca525835be9d5db1f16d6b22be12f4cd4
+  languageName: node
+  linkType: hard
+
+"react-hook-form@npm:^7.53.0":
+  version: 7.53.0
+  resolution: "react-hook-form@npm:7.53.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17 || ^18 || ^19
+  checksum: 10c0/6d62b150618a833c17d59e669b707661499e2bb516a8d340ca37699f99eb448bbba7b5b78324938c8948014e21efaa32e3510c2ba246fd5e97a96fca0cfa7c98
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 변경점

- 버튼의 variant 중 필요가 없는 light-outlined를 없애고 대신 primary를 추가했습니다. 아래와 같이 사용이 가능합니다. (가입, 스터디 생성 등 모달에서 사용되는 버튼)
```typescript
<Button variant="primary" css={{ borderRadius: theme.corners.small, width: '100%' }}>가입하기</Button>
```
- 버튼에서 disabled 스타일을 제공합니다. disabled prop을 전달하면 잘 작동함을 확인할 수 있습니다.
![image](https://github.com/user-attachments/assets/f712ec4e-a14c-4ec5-9600-7d8c09ee77af)
- study creation form validation을 구현했습니다. 
- 스터디 관련 타입을 일부 정의했습니다. types/study/index.d.ts에 정의해두었으나, 추후에 request, response 등 스터디와 관련된 여러개의 타입을 한 파일안에 정의하면 보기 불편할 수 있으니 관리 방식에 대한 논의가 필요합니다.
- react-hook-form 라이브러리와 함께 사용할 수 있는 에러메시지 컴포넌트를 작성했습니다. 사용법은 다음과 같습니다.
```typescript
<FormErrorMessage errors={errors} name="description" />
// errors는 react-hook-form/useForm()의 return value, name은 필드명
```